### PR TITLE
Add verify

### DIFF
--- a/bin/verify.js
+++ b/bin/verify.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const { verify } = require('../src/verify');
+
+(async () => {
+  try {
+    await verify();
+  } catch (err) {
+    console.error('An unexpected error occurred', err);
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "couchdb-migration",
   "version": "1.0.0",
-  "description": "Tool to help in migrating data within a CouchDb cluster.",
+  "description": "Tool that interfaces with CouchDB to help migrating data within a cluster.",
   "scripts": {
     "eslint": "eslint --color --cache ./src ./test",
     "unit": "mocha ./test/unit/**/*.js --config ./test/unit/mocharc.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "move-node": "bin/move-node.js",
     "move-shard": "bin/move-shard.js",
     "move-shards": "bin/move-shards.js",
-    "remove-node": "bin/remove-node.js"
+    "remove-node": "bin/remove-node.js",
+    "verify": "bin/verify.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "move-node": "bin/move-node.js",
     "move-shard": "bin/move-shard.js",
     "move-shards": "bin/move-shards.js",
-    "remove-node": "bin/remove-node.js",   
+    "remove-node": "bin/remove-node.js",
     "check-couchdb-up": "bin/check-couchdb-up.js",
     "pre-index-views": "bin/pre-index-views.js",
     "verify": "bin/verify.js"

--- a/src/verify.js
+++ b/src/verify.js
@@ -38,6 +38,7 @@ const verifyDb = async (dbName) => {
   await utils.syncShards(dbName);
 
   const url = utils.getUrl(`${dbName}/_all_docs`, false, 'limit=0');
+  console.log(url);
   const allDocsResponse = await utils.request({ url });
 
   const viewsIndexed = await verifyViews(dbName, allDocsResponse.total_rows);
@@ -57,8 +58,8 @@ const verify = async () => {
     try {
       await verifyDb(dbName);
     } catch (err) {
-      console.error('Error when checking', dbName, err);
-      throw new Error('Verification failed.');
+      console.error('Error when checking database ', dbName, err);
+      throw new Error(`Verification failed for database ${dbName}`);
     }
   }
 };

--- a/src/verify.js
+++ b/src/verify.js
@@ -38,7 +38,6 @@ const verifyDb = async (dbName) => {
   await utils.syncShards(dbName);
 
   const url = utils.getUrl(`${dbName}/_all_docs`, false, 'limit=0');
-  console.log(url);
   const allDocsResponse = await utils.request({ url });
 
   const viewsIndexed = await verifyViews(dbName, allDocsResponse.total_rows);

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,0 +1,68 @@
+const utils = require('./utils');
+
+const verifyViews = async (dbName, numDocs) => {
+  if (!numDocs) {
+    return true;
+  }
+
+  const url = utils.getUrl(`${dbName}/_design_docs`, false, 'include_docs=true');
+  const response = await utils.request({ url });
+
+  let viewsIndexed = false;
+  let viewsChecked = false;
+
+  for (const { doc: ddoc } of response.rows) {
+    if (!ddoc || !ddoc.views) {
+      continue;
+    }
+
+    const views = Object.keys(ddoc.views);
+    for (const view of views) {
+      viewsChecked = true;
+      const url = utils.getUrl(`${dbName}/${ddoc._id}/_view/${view}`, false, 'stale=ok&limit=0');
+      const viewResponse = await utils.request({ url });
+
+      if (viewResponse.total_rows > 0) {
+        // at least one view being indexed means that the .shard folders for the database were moved successfully
+        // some views might not index any documents
+        viewsIndexed = true;
+      }
+    }
+  }
+
+  return !viewsChecked || (viewsChecked && viewsIndexed);
+};
+
+const verifyDb = async (dbName) => {
+  console.info(`Verifying ${dbName}`);
+  await utils.syncShards(dbName);
+
+  const url = utils.getUrl(`${dbName}/_all_docs`, false, 'limit=0');
+  const allDocsResponse = await utils.request({ url });
+
+  const viewsIndexed = await verifyViews(dbName, allDocsResponse.total_rows);
+  if (viewsIndexed) {
+    console.info(`Database ${dbName} has passed migration checks.`);
+  } else {
+    console.warn(`
+      Views of database ${dbName} are not indexed. 
+      This can be caused by a migration failure or by the the views functions not indexing any documents.
+    `);
+  }
+};
+
+const verify = async () => {
+  const allDbs = await utils.getDbs();
+  for (const dbName of allDbs) {
+    try {
+      await verifyDb(dbName);
+    } catch (err) {
+      console.error('Error when checking', dbName, err);
+      throw new Error('Verification failed.');
+    }
+  }
+};
+
+module.exports = {
+  verify,
+};

--- a/src/verify.js
+++ b/src/verify.js
@@ -12,13 +12,8 @@ const verifyViews = async (dbName, numDocs) => {
   if (!ddocsWithViews.length) {
     return true;
   }
-  for (const { doc: ddoc } of response.rows) {
-    if (!ddoc || !ddoc.views) {
-      continue;
-    }
-
-    const views = Object.keys(ddoc.views);
-    for (const view of views) {
+  for (const { doc: ddoc } of ddocsWithViews) {
+    for (const view of Object.keys(ddoc.views)) {
       const url = utils.getUrl(`${dbName}/${ddoc._id}/_view/${view}`, false, 'stale=ok&limit=0');
       const viewResponse = await utils.request({ url });
 

--- a/test/e2e/multi-node.sh
+++ b/test/e2e/multi-node.sh
@@ -84,6 +84,7 @@ docker-compose -f ../../docker-compose.yml run couch-migration shard-move-instru
 node ./scripts/distribute-shards.js $shard_matrix $file_matrix
 # change database metadata to match the shard physical locations
 docker-compose -f ../../docker-compose.yml run couch-migration move-shards $shard_matrix
+docker-compose -f ../../docker-compose.yml run couch-migration verify
 # test that data exists, database shard maps are correct and view indexes are preserved
 node ./scripts/assert-dbs.js $jsondataddir $shard_matrix
 

--- a/test/e2e/single-node.sh
+++ b/test/e2e/single-node.sh
@@ -52,6 +52,7 @@ docker-compose -f ./scripts/couchdb-single.yml up -d
 waitForStatus $HOST_COUCH_URL 200
 # change database metadata to match new node name
 docker-compose -f ../../docker-compose.yml run couch-migration move-node
+docker-compose -f ../../docker-compose.yml run couch-migration verify
 # test that data exists, database shard maps are correct and view indexes are preserved
 node ./scripts/assert-dbs.js $jsondataddir
 

--- a/test/unit/verify.spec.js
+++ b/test/unit/verify.spec.js
@@ -4,193 +4,193 @@ const verify = require('../../src/verify');
 const couchUrl = utils.couchUrl.toString();
 
 describe('verify', () => {
-  describe('verity', () => {
-    it('should check every database', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one', 'two']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
 
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 100 });
-      utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).resolves({ total_rows: 200 });
+  it('should check every database', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one', 'two']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
 
-      utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({
-        rows: [
-          { doc: { _id: '_design/one', views: { a: {}, b: {} } } },
-          { doc: { _id: '_design/two', views: { c: {}, d: {} } } },
-        ]
-      });
-      utils.request.withArgs({ url: `${couchUrl}two/_design_docs?include_docs=true` }).resolves({
-        rows: [
-          { doc: { _id: '_design/a', views: { 1: {}, 2: {} } } },
-          { doc: { _id: '_design/b', views: { 3: {}, 4: {} } } },
-        ]
-      });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` })
-        .resolves({ total_rows: 1 });
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 100 });
+    utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).resolves({ total_rows: 200 });
 
-      utils.request
-        .withArgs({ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` })
-        .resolves({ total_rows: 12 });
-
-      await verify.verify();
-
-      expect(utils.syncShards.args).to.deep.equal([['one'], ['two']]);
-      expect(utils.request.args).to.deep.equal([
-        [{ url: `${couchUrl}one/_all_docs?limit=0` }],
-        [{ url: `${couchUrl}one/_design_docs?include_docs=true` }],
-        [{ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` }],
-        [{ url: `${couchUrl}two/_all_docs?limit=0` }],
-        [{ url: `${couchUrl}two/_design_docs?include_docs=true` }],
-        [{ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` }],
-      ]);
+    utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({
+      rows: [
+        { doc: { _id: '_design/one', views: { a: {}, b: {} } } },
+        { doc: { _id: '_design/two', views: { c: {}, d: {} } } },
+      ]
     });
-
-    it('should handle databases with no docs', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 0 });
-
-      await verify.verify();
-
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(1);
+    utils.request.withArgs({ url: `${couchUrl}two/_design_docs?include_docs=true` }).resolves({
+      rows: [
+        { doc: { _id: '_design/a', views: { 1: {}, 2: {} } } },
+        { doc: { _id: '_design/b', views: { 3: {}, 4: {} } } },
+      ]
     });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` })
+      .resolves({ total_rows: 1 });
 
-    it('should handle databases with no ddocs', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({ rows: [] });
+    utils.request
+      .withArgs({ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` })
+      .resolves({ total_rows: 12 });
 
-      await verify.verify();
+    await verify.verify();
 
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(2);
-    });
+    expect(utils.syncShards.args).to.deep.equal([['one'], ['two']]);
+    expect(utils.request.args).to.deep.equal([
+      [{ url: `${couchUrl}one/_all_docs?limit=0` }],
+      [{ url: `${couchUrl}one/_design_docs?include_docs=true` }],
+      [{ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` }],
+      [{ url: `${couchUrl}two/_all_docs?limit=0` }],
+      [{ url: `${couchUrl}two/_design_docs?include_docs=true` }],
+      [{ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` }],
+    ]);
+  });
 
-    it('should handle databases with no views', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
-        .resolves({ rows: [{ doc: { _id: '_design/a' } }] });
+  it('should handle databases with no docs', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 0 });
 
-      await verify.verify();
+    await verify.verify();
 
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(2);
-    });
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(1);
+  });
 
-    it('should pass verification when at least one view is indexed', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
-        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+  it('should handle databases with no ddocs', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({ rows: [] });
 
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
-        .resolves({ total_rows: 0 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
-        .resolves({ total_rows: 1 });
+    await verify.verify();
+
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(2);
+  });
+
+  it('should handle databases with no views', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+      .resolves({ rows: [{ doc: { _id: '_design/a' } }] });
+
+    await verify.verify();
+
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(2);
+  });
+
+  it('should pass verification when at least one view is indexed', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+      .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+      .resolves({ total_rows: 0 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+      .resolves({ total_rows: 1 });
 
 
-      await verify.verify();
+    await verify.verify();
 
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(4);
-    });
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(4);
+  });
 
-    it('should pass verification when none of the views are indexed', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
-        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+  it('should pass verification when none of the views are indexed', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+      .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
 
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
-        .resolves({ total_rows: 0 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
-        .resolves({ total_rows: 0 });
-      sinon.spy(console, 'warn');
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+      .resolves({ total_rows: 0 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+      .resolves({ total_rows: 0 });
+    sinon.spy(console, 'warn');
 
-      await verify.verify();
+    await verify.verify();
 
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(4);
-      expect(console.warn.args).to.deep.equal([[`
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(4);
+    expect(console.warn.args).to.deep.equal([[`
       Views of database one are not indexed. 
       This can be caused by a migration failure or by the the views functions not indexing any documents.
     `]]);
-    });
-
-    it('should fail verification when syncShards fails', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').rejects(new Error('omg'));
-
-      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
-
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-    });
-
-    it('should fail verification when _all_docs fails', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['two']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).rejects(new Error('wha'));
-
-      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database two');
-
-      expect(utils.syncShards.args).to.deep.equal([['two']]);
-      expect(utils.request.callCount).to.equal(1);
-    });
-
-    it('should fail verification when _design_docs fails', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['three']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}three/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request.withArgs({ url: `${couchUrl}three/_design_docs?include_docs=true` }).rejects(new Error('t'));
-
-      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database three');
-
-      expect(utils.syncShards.args).to.deep.equal([['three']]);
-      expect(utils.request.callCount).to.equal(2);
-    });
-
-    it('should fail verification when view request fails', async () => {
-      sinon.stub(utils, 'getDbs').resolves(['one']);
-      sinon.stub(utils, 'syncShards').resolves();
-      sinon.stub(utils, 'request');
-      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
-        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
-
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
-        .resolves({ total_rows: 0 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
-        .rejects(new Error('w'));
-
-
-      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
-
-      expect(utils.syncShards.args).to.deep.equal([['one']]);
-      expect(utils.request.callCount).to.equal(4);
-    });
   });
+
+  it('should fail verification when syncShards fails', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').rejects(new Error('omg'));
+
+    await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
+
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+  });
+
+  it('should fail verification when _all_docs fails', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['two']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).rejects(new Error('wha'));
+
+    await expect(verify.verify()).to.be.rejectedWith('Verification failed for database two');
+
+    expect(utils.syncShards.args).to.deep.equal([['two']]);
+    expect(utils.request.callCount).to.equal(1);
+  });
+
+  it('should fail verification when _design_docs fails', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['three']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}three/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request.withArgs({ url: `${couchUrl}three/_design_docs?include_docs=true` }).rejects(new Error('t'));
+
+    await expect(verify.verify()).to.be.rejectedWith('Verification failed for database three');
+
+    expect(utils.syncShards.args).to.deep.equal([['three']]);
+    expect(utils.request.callCount).to.equal(2);
+  });
+
+  it('should fail verification when view request fails', async () => {
+    sinon.stub(utils, 'getDbs').resolves(['one']);
+    sinon.stub(utils, 'syncShards').resolves();
+    sinon.stub(utils, 'request');
+    utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+      .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+      .resolves({ total_rows: 0 });
+    utils.request
+      .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+      .rejects(new Error('w'));
+
+
+    await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
+
+    expect(utils.syncShards.args).to.deep.equal([['one']]);
+    expect(utils.request.callCount).to.equal(4);
+  });
+
 });

--- a/test/unit/verify.spec.js
+++ b/test/unit/verify.spec.js
@@ -1,0 +1,207 @@
+const utils = require('../../src/utils');
+const verify = require('../../src/verify');
+
+const couchUrl = utils.couchUrl.toString();
+
+describe('verify', () => {
+  describe('verity', () => {
+    it('should check every database', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one', 'two']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 100 });
+      utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).resolves({ total_rows: 200 });
+
+      utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({
+        rows: [
+          { doc: { _id: '_design/one', views: { a: {}, b: {} } } },
+          { doc: { _id: '_design/two', views: { c: {}, d: {} } } },
+        ]
+      });
+      utils.request.withArgs({ url: `${couchUrl}two/_design_docs?include_docs=true` }).resolves({
+        rows: [
+          { doc: { _id: '_design/a', views: { 1: {}, 2: {} } } },
+          { doc: { _id: '_design/b', views: { 3: {}, 4: {} } } },
+        ]
+      });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` })
+        .resolves({ total_rows: 1 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/one/_view/b?stale=ok&limit=0` })
+        .resolves({ total_rows: 2 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/two/_view/c?stale=ok&limit=0` })
+        .resolves({ total_rows: 4 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/two/_view/d?stale=ok&limit=0` })
+        .resolves({ total_rows: 12 });
+
+      utils.request
+        .withArgs({ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` })
+        .resolves({ total_rows: 12 });
+      utils.request
+        .withArgs({ url: `${couchUrl}two/_design/a/_view/2?stale=ok&limit=0` })
+        .resolves({ total_rows: 1 });
+      utils.request
+        .withArgs({ url: `${couchUrl}two/_design/b/_view/3?stale=ok&limit=0` })
+        .resolves({ total_rows: 22 });
+      utils.request
+        .withArgs({ url: `${couchUrl}two/_design/b/_view/4?stale=ok&limit=0` })
+        .resolves({ total_rows: 1 });
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one'], ['two']]);
+      expect(utils.request.callCount).to.equal(12);
+    });
+
+    it('should handle databases with no docs', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 0 });
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(1);
+    });
+
+    it('should handle databases with no ddocs', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request.withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` }).resolves({ rows: [] });
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(2);
+    });
+
+    it('should handle databases with no views', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+        .resolves({ rows: [{ doc: { _id: '_design/a' } }] });
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(2);
+    });
+
+    it('should pass verification when at least one view is indexed', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+        .resolves({ total_rows: 0 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+        .resolves({ total_rows: 1 });
+
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(4);
+    });
+
+    it('should pass verification when none of the views are indexed', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+        .resolves({ total_rows: 0 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+        .resolves({ total_rows: 0 });
+      sinon.spy(console, 'warn');
+
+      await verify.verify();
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(4);
+      expect(console.warn.args).to.deep.equal([[`
+      Views of database one are not indexed. 
+      This can be caused by a migration failure or by the the views functions not indexing any documents.
+    `]]);
+    });
+
+    it('should fail verification when syncShards fails', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').rejects(new Error('omg'));
+
+      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+    });
+
+    it('should fail verification when _all_docs fails', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['two']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}two/_all_docs?limit=0` }).rejects(new Error('wha'));
+
+      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database two');
+
+      expect(utils.syncShards.args).to.deep.equal([['two']]);
+      expect(utils.request.callCount).to.equal(1);
+    });
+
+    it('should fail verification when _design_docs fails', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['three']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}three/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request.withArgs({ url: `${couchUrl}three/_design_docs?include_docs=true` }).rejects(new Error('t'));
+
+      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database three');
+
+      expect(utils.syncShards.args).to.deep.equal([['three']]);
+      expect(utils.request.callCount).to.equal(2);
+    });
+
+    it('should fail verification when view request fails', async () => {
+      sinon.stub(utils, 'getDbs').resolves(['one']);
+      sinon.stub(utils, 'syncShards').resolves();
+      sinon.stub(utils, 'request');
+      utils.request.withArgs({ url: `${couchUrl}one/_all_docs?limit=0` }).resolves({ total_rows: 10 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design_docs?include_docs=true` })
+        .resolves({ rows: [{ doc: { _id: '_design/a', views: { a: {}, b: {} } } }] });
+
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/a?stale=ok&limit=0` })
+        .resolves({ total_rows: 0 });
+      utils.request
+        .withArgs({ url: `${couchUrl}one/_design/a/_view/b?stale=ok&limit=0` })
+        .rejects(new Error('w'));
+
+
+      await expect(verify.verify()).to.be.rejectedWith('Verification failed for database one');
+
+      expect(utils.syncShards.args).to.deep.equal([['one']]);
+      expect(utils.request.callCount).to.equal(4);
+    });
+  });
+});

--- a/test/unit/verify.spec.js
+++ b/test/unit/verify.spec.js
@@ -28,33 +28,22 @@ describe('verify', () => {
       utils.request
         .withArgs({ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` })
         .resolves({ total_rows: 1 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/one/_view/b?stale=ok&limit=0` })
-        .resolves({ total_rows: 2 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/two/_view/c?stale=ok&limit=0` })
-        .resolves({ total_rows: 4 });
-      utils.request
-        .withArgs({ url: `${couchUrl}one/_design/two/_view/d?stale=ok&limit=0` })
-        .resolves({ total_rows: 12 });
 
       utils.request
         .withArgs({ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` })
         .resolves({ total_rows: 12 });
-      utils.request
-        .withArgs({ url: `${couchUrl}two/_design/a/_view/2?stale=ok&limit=0` })
-        .resolves({ total_rows: 1 });
-      utils.request
-        .withArgs({ url: `${couchUrl}two/_design/b/_view/3?stale=ok&limit=0` })
-        .resolves({ total_rows: 22 });
-      utils.request
-        .withArgs({ url: `${couchUrl}two/_design/b/_view/4?stale=ok&limit=0` })
-        .resolves({ total_rows: 1 });
 
       await verify.verify();
 
       expect(utils.syncShards.args).to.deep.equal([['one'], ['two']]);
-      expect(utils.request.callCount).to.equal(12);
+      expect(utils.request.args).to.deep.equal([
+        [{ url: `${couchUrl}one/_all_docs?limit=0` }],
+        [{ url: `${couchUrl}one/_design_docs?include_docs=true` }],
+        [{ url: `${couchUrl}one/_design/one/_view/a?stale=ok&limit=0` }],
+        [{ url: `${couchUrl}two/_all_docs?limit=0` }],
+        [{ url: `${couchUrl}two/_design_docs?include_docs=true` }],
+        [{ url: `${couchUrl}two/_design/a/_view/1?stale=ok&limit=0` }],
+      ]);
     });
 
     it('should handle databases with no docs', async () => {


### PR DESCRIPTION
Add verify command which: 
- does sync_shards for every DB
- does an _all_docs request (with limit 0
- checks view indexes (returning results on a stale request is 👍🏻 ) 

Caveat for views: if the view has no docs to index (none of the docs emit in the view), we will get false failures, so on no doc views we just display a warning. Wording of the warning can definitely be improved. 